### PR TITLE
Fixed search results were not limited to the selected language.

### DIFF
--- a/src/LanguageSearch.php
+++ b/src/LanguageSearch.php
@@ -42,7 +42,7 @@ class LanguageSearch {
 	public function filterByLang( $args ) {
 		$args['post_filter']['bool']['must'][] = [
 			'term' => [
-				'post_lang' => $this->getQueryLang(),
+				'post_lang.keyword' => $this->getQueryLang(),
 			],
 		];
 


### PR DESCRIPTION
By default the [index language](https://github.com/10up/ElasticPress/blob/develop/includes/mappings/post/7-0.php#L93) is set to english and uses the stop word filter which contains the word `it`. Since this string is also the locale for the Italian language posts were not limited or not showing up when searching in this particular language. This could be fixed by changing the search field from an analysed text field to the keyword field.

Query:
```
GET /<my_index>/_analyze
{
  "field": "post_lang", 
  "text" : "it"
}
```
Result:
```
{
  "tokens" : [ ]
}
```
---
Query:
```
GET /<my_index>/_analyze
{
  "field": "post_lang.keyword", 
  "text" : "it"
}
```
Result:
```
{
  "tokens" : [
    {
      "token" : "it",
      "start_offset" : 0,
      "end_offset" : 2,
      "type" : "word",
      "position" : 0
    }
  ]
}
```
---

> When not customized, the filter removes the following English stop words by default:
> a, an, and, are, as, at, be, but, by, for, if, in, into, is, it, no, not, of, on, or, such, that, the, their, then, there, these, they, this, to, was, will, with
Source: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-stop-tokenfilter.html

More information:
- https://stackoverflow.com/a/48875105/2862127
- https://www.elastic.co/blog/strings-are-dead-long-live-strings