### PR TITLE
fix: custom analyzer for the post_lang field

### DIFF
--- a/src/IndexingLangParam.php
+++ b/src/IndexingLangParam.php
@@ -2,22 +2,31 @@
 
 namespace WPML\ElasticPress;
 
+use ElasticPress\Elasticsearch;
 
 class IndexingLangParam {
+	/** @var Elasticsearch */
+	private $elasticsearch;
+
 	/** @var \SitePress */
 	private $sitepress;
 
 	/**
 	 * @param  \SitePress  $sitepress
 	 */
-	public function __construct( \SitePress $sitepress ) {
-		$this->sitepress = $sitepress;
+	public function __construct(
+		Elasticsearch $elasticsearch,
+		\SitePress $sitepress
+	) {
+		$this->elasticsearch = $elasticsearch;
+		$this->sitepress     = $sitepress;
 	}
 
 
 	public function addHooks() {
 		add_action( 'ep_pre_dashboard_index', [ $this, 'setsALLLangForDashboardIndexing' ], 10, 0 );
 		add_action( 'ep_wp_cli_pre_index', [ $this, 'setLangForCLIIndexing' ], 10, 2 );
+		add_filter( 'ep_post_mapping', [ $this, 'mapping' ] );
 	}
 
 	public function setsALLLangForDashboardIndexing() {
@@ -43,4 +52,31 @@ class IndexingLangParam {
 
 		return 'all';
 	}
+
+	/**
+	 * @param  array $mapping
+	 * @return array
+	 */
+	public function mapping( $mapping ) {
+		// Define an analyzer with no filters (no stopwords).
+		$mapping['settings']['analysis']['analyzer']['post_lang_field'] = array(
+			'type'      => 'custom',
+			'tokenizer' => 'standard',
+			'filter'    => [],
+		);
+
+		// Note the assignment by reference below.
+		if ( version_compare( $this->elasticsearch->get_elasticsearch_version(), '7.0', '<' ) ) {
+			$mapping_properties = &$mapping['mappings']['post']['properties'];
+		} else {
+			$mapping_properties = &$mapping['mappings']['properties'];
+		}
+
+		// Apply the analized.
+		$mapping_properties['post_lang']['type']     = 'text';
+		$mapping_properties['post_lang']['analyzer'] = 'post_lang_field';
+
+		return $mapping;
+	}
+
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,7 +15,10 @@ class Plugin {
 						new \WPML_Translation_Element_Factory( $sitepress ),
 						$sitepress
 					),
-					new IndexingLangParam( $sitepress )
+					new IndexingLangParam(
+						\ElasticPress\Elasticsearch::factory(),
+						$sitepress
+					)
 				);
 
 				\ElasticPress\Features::factory()->register_feature( $feature );


### PR DESCRIPTION
- Removes filtering, including stopwords.
- Avpids clashes when a lang key is a stopword in the default language, like it.

Ref: wpmlbridge-263