### PR TITLE
fix: post types set to display as translated

### DIFF
--- a/src/LanguageSearch.php
+++ b/src/LanguageSearch.php
@@ -29,7 +29,7 @@ class LanguageSearch {
 	 * @return array
 	 */
 	public function addLangInfo( $post_args, $post_id ) {
-		if ( $this->sitepress->is_display_as_translated_post_type( $post_args["post_type"] ) ) {
+		if ( $this->sitepress->is_display_as_translated_post_type( $post_args['post_type'] ) ) {
 			$post_args['post_lang'] = $this->getPostLangAsTranslated( $post_args, $post_id );
 		} else {
 			$post_args['post_lang'] = $this->getPostLang( $post_args, $post_id );
@@ -81,13 +81,12 @@ class LanguageSearch {
 
 	private function getPostLangAsTranslated( $post_args, $post_id ) {
 		$active_languages = array_keys( $this->sitepress->get_active_languages() );
-		$trid             = apply_filters( 'wpml_element_trid', null, $post_id, 'post_' . $post_args["post_type"] );
-		$translations     = apply_filters( 'wpml_get_element_translations', null, $trid, 'post_' . $post_args["post_type"] );
-		foreach ( $active_languages as $language ) {
+		$element_type     = apply_filters( 'wpml_element_type', $post_args['post_type'] );
+		$trid             = apply_filters( 'wpml_element_trid', null, $post_id, $element_type );
+		$translations     = apply_filters( 'wpml_get_element_translations', null, $trid, $element_type );
+		foreach ( $active_languages as $key => $language ) {
 			if ( array_key_exists( $language, $translations ) && $translations[ $language ]->element_id != $post_id ) {
-				if ( ( $key = array_search( $language, $active_languages ) ) !== false ) {
-					unset( $active_languages[ $key ] );
-				}
+				unset( $active_languages[ $key ] );
 			}
 		}
 


### PR DESCRIPTION
Include all relevant languages in the `post_lang` field so the default language appears in the right searches.

Ref: compdev-91

Obsoletes https://github.com/OnTheGoSystems/wpml-elasticpress/pull/12