### PR TITLE
fix: non-translatable posts in general indexes

### DIFF
--- a/src/IndexingLangParam.php
+++ b/src/IndexingLangParam.php
@@ -24,17 +24,48 @@ class IndexingLangParam {
 
 
 	public function addHooks() {
-		add_action( 'ep_pre_dashboard_index', [ $this, 'setsALLLangForDashboardIndexing' ], 10, 0 );
+		add_filter( 'ep_dashboard_index_args', [ $this, 'setDashboardIndexArgs' ] );
 		add_action( 'ep_wp_cli_pre_index', [ $this, 'setLangForCLIIndexing' ], 10, 2 );
+		add_filter( 'ep_cli_index_args', [ $this, 'setCliIndexArgs' ] );
 		add_filter( 'ep_post_mapping', [ $this, 'mapping' ] );
 	}
 
-	public function setsALLLangForDashboardIndexing() {
-		$this->sitepress->switch_lang( 'all' );
+	/**
+	 * Dashboard index includes all posts
+	 *
+	 * @param  array $args
+	 *
+	 * @return array
+	 */
+	public function setDashboardIndexArgs( $args ) {
+		$args['suppress_wpml_where_and_join_filter'] = true;
+		return $args;
 	}
 
+	/**
+	 * Set lang for CLI index based on the --post-lang flag
+	 *
+	 * @param  array $args
+	 * @param  array $assocArgs
+	 *
+	 * @return array
+	 */
 	public function setLangForCLIIndexing( array $args, array $assocArgs ) {
 		$this->sitepress->switch_lang( $this->getLangFromArgs( $assocArgs ) );
+	}
+
+	/**
+	 * CLI index might include all posts
+	 *
+	 * @param  array $args
+	 *
+	 * @return array
+	 */
+	public function setCliIndexArgs( $args ) {
+		if ( 'all' === apply_filters( 'wpml_current_language', null ) ) {
+			$args['suppress_wpml_where_and_join_filter'] = true;
+		}
+		return $args;
 	}
 
 	/**

--- a/tests/phpunit/IndexingLangParamTest.php
+++ b/tests/phpunit/IndexingLangParamTest.php
@@ -15,8 +15,9 @@ class IndexingLangParamTest extends \OTGS_TestCase {
 			$this->getSitePresMock()
 		);
 
-		\WP_Mock::expectActionAdded( 'ep_pre_dashboard_index', [ $subject, 'setsALLLangForDashboardIndexing' ], 10, 0 );
+		\WP_Mock::expectFilterAdded( 'ep_dashboard_index_args', [ $subject, 'setDashboardIndexArgs' ] );
 		\WP_Mock::expectActionAdded( 'ep_wp_cli_pre_index', [ $subject, 'setLangForCLIIndexing' ], 10, 2 );
+		\WP_Mock::expectFilterAdded( 'ep_cli_index_args', [ $subject, 'setCliIndexArgs' ] );
 		\WP_Mock::expectFilterAdded( 'ep_post_mapping', [ $subject, 'mapping' ] );
 
 		$subject->addHooks();


### PR DESCRIPTION
* Setting the language to `all` excludes non-translatable post types.
* Suppressing where and join filters ensures that all posts are included.

Ref: wpmlbridge-265