### PR TITLE
fix: ensure CLI command works

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It lets us filter them later.
 We also added the extra `--post-lang` argument in CLI indexing command.
 You can use it in this way:
 
-`wp wpml_elasticpress index --post-type=post --post-lang=de` which will index only German posts.
+`wp wpml_elasticpress sync --post-type=post --post-lang=de` which will index only German posts.
 
 ## Building from source
 

--- a/src/Command.php
+++ b/src/Command.php
@@ -5,19 +5,30 @@ namespace WPML\ElasticPress;
 
 
 class Command extends \ElasticPress\Command {
+	// Extending the native class to add `--post-lang` argument
 
 	/**
-	 * I have to override it to add `--post-lang` argument
-	 *
 	 * Index all posts for a site or network wide
 	 *
 	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--post-lang]
-	 * @param  array  $args  Positional CLI args.
-	 * @param  array  $assoc_args  Associative CLI args.
+	 * @param array  $args  Positional CLI args.
+	 * @param array  $assoc_args  Associative CLI args.
 	 *
 	 * @since 0.1.2
+	 * @deprecated
 	 */
 	public function index( $args, $assoc_args ) {
-		return parent::index( $args, $assoc_args );
+		return parent::sync( $args, $assoc_args );
+	}
+
+	/**
+	 * Sync all posts for a site or network wide
+	 *
+	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--post-lang]
+	 * @param array  $args  Positional CLI args.
+	 * @param array  $assoc_args  Associative CLI args.
+	 */
+	public function sync( $args, $assoc_args ) {
+		return parent::sync( $args, $assoc_args );
 	}
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -15,9 +15,12 @@ class Command extends \ElasticPress\Command {
 	 * @param array  $assoc_args  Associative CLI args.
 	 *
 	 * @since 0.1.2
-	 * @deprecated
+	 * @deprecated on ElasticPress 4.4.0
 	 */
 	public function index( $args, $assoc_args ) {
+		if ( version_compare( EP_VERSION, '4.4.0', '<' ) ) {
+			return parent::index( $args, $assoc_args );
+		}
 		return parent::sync( $args, $assoc_args );
 	}
 
@@ -29,6 +32,6 @@ class Command extends \ElasticPress\Command {
 	 * @param array  $assoc_args  Associative CLI args.
 	 */
 	public function sync( $args, $assoc_args ) {
-		return parent::sync( $args, $assoc_args );
+		return $this->index( $args, $assoc_args );
 	}
 }


### PR DESCRIPTION
* Deprecate the `index` method.
* Include a `sync` method.

See https://github.com/10up/ElasticPress/blob/develop/CHANGELOG.md#440---2022-11-29

Ref: wpmlbridge-268