### PR TITLE
Fix post filter for lang codes with a dash (zh-hans)

### DIFF
--- a/src/IndexingLangParam.php
+++ b/src/IndexingLangParam.php
@@ -107,6 +107,12 @@ class IndexingLangParam {
 		// Apply the analyzer.
 		$mapping_properties['post_lang']['type']     = 'text';
 		$mapping_properties['post_lang']['analyzer'] = 'post_lang_field';
+		$mapping_properties['post_lang']['fields'] = array(
+			'keyword' => array(
+				'type' => 'keyword',
+				'ignore_above' => '256',
+			)
+		);
 
 		return $mapping;
 	}

--- a/src/LanguageSearch.php
+++ b/src/LanguageSearch.php
@@ -46,7 +46,7 @@ class LanguageSearch {
 	public function filterByLang( $args ) {
 		$args['post_filter']['bool']['must'][] = [
 			'term' => [
-				'post_lang' => $this->getQueryLang(),
+				'post_lang.keyword' => $this->getQueryLang(),
 			],
 		];
 


### PR DESCRIPTION
Added `keyword` for `post_lang` in order to fix filtering by "zh-hans".

Language codes with dashes give multiple tokens when analyzed:
```
POST /:index/_analyze
{
    "analyzer": "post_lang_field",
    "text": "zh-hans"
}
```
```
{
    "tokens": [
        {
            "token": "zh",
            "start_offset": 0,
            "end_offset": 2,
            "type": "<ALPHANUM>",
            "position": 0
        },
        {
            "token": "hans",
            "start_offset": 3,
            "end_offset": 7,
            "type": "<ALPHANUM>",
            "position": 1
        }
    ]
}
```
And this filter always gives 0 results:
```
'term' => [
	'post_lang' => 'zh-hans',
],
```
So in order to fix the post filtering issue for such language codes we need to either use additional "keyword" field with "keyword" data type or use "keyword" analyzer for `post_lang` field or just map `post_lang` field to "keyword" data type.