### PR TITLE
fix: sync languages including a dash

### DIFF
--- a/src/IndexingLangParam.php
+++ b/src/IndexingLangParam.php
@@ -91,10 +91,14 @@ class IndexingLangParam {
 	 */
 	public function mapping( $mapping ) {
 		// Define an analyzer with no filters (no stopwords).
-		$mapping['settings']['analysis']['analyzer']['post_lang_field'] = array(
+		$mapping['settings']['analysis']['analyzer']['post_lang_field']      = array(
 			'type'      => 'custom',
-			'tokenizer' => 'standard',
+			'tokenizer' => 'post_lang_tokenizer',
 			'filter'    => [],
+		);
+		$mapping['settings']['analysis']['tokenizer']['post_lang_tokenizer'] = array(
+			'type'              => 'char_group',
+			'tokenize_on_chars' => [ ',' ],
 		);
 
 		// Note the assignment by reference below.

--- a/tests/phpunit/IndexingLangParamTest.php
+++ b/tests/phpunit/IndexingLangParamTest.php
@@ -82,8 +82,14 @@ class IndexingLangParamTest extends \OTGS_TestCase {
 					'analyzer' => [
 						'post_lang_field' => [
 							'type'      => 'custom',
-							'tokenizer' => 'standard',
+							'tokenizer' => 'post_lang_tokenizer',
 							'filter'    => [],
+						],
+					],
+					'tokenizer' => [
+						'post_lang_tokenizer' => [
+							'type'              => 'char_group',
+							'tokenize_on_chars' => [ ',' ],
 						],
 					],
 				],
@@ -132,8 +138,14 @@ class IndexingLangParamTest extends \OTGS_TestCase {
 					'analyzer' => [
 						'post_lang_field' => [
 							'type'      => 'custom',
-							'tokenizer' => 'standard',
+							'tokenizer' => 'post_lang_tokenizer',
 							'filter'    => [],
+						],
+					],
+					'tokenizer' => [
+						'post_lang_tokenizer' => [
+							'type'              => 'char_group',
+							'tokenize_on_chars' => [ ',' ],
 						],
 					],
 				],


### PR DESCRIPTION
Use a proper tokenizer for the post-lang field.

Ref: wpmlbridge-263