### PR TITLE
fix: use pattern analizer for lang fields

### DIFF
--- a/src/IndexingLangParam.php
+++ b/src/IndexingLangParam.php
@@ -97,8 +97,8 @@ class IndexingLangParam {
 			'filter'    => [],
 		);
 		$mapping['settings']['analysis']['tokenizer']['post_lang_tokenizer'] = array(
-			'type'              => 'char_group',
-			'tokenize_on_chars' => [ ',' ],
+			'type'    => 'pattern',
+			'pattern' => ',',
 		);
 
 		// Note the assignment by reference below.

--- a/tests/phpunit/IndexingLangParamTest.php
+++ b/tests/phpunit/IndexingLangParamTest.php
@@ -88,8 +88,8 @@ class IndexingLangParamTest extends \OTGS_TestCase {
 					],
 					'tokenizer' => [
 						'post_lang_tokenizer' => [
-							'type'              => 'char_group',
-							'tokenize_on_chars' => [ ',' ],
+							'type'    => 'pattern',
+							'pattern' => ',',
 						],
 					],
 				],
@@ -144,8 +144,8 @@ class IndexingLangParamTest extends \OTGS_TestCase {
 					],
 					'tokenizer' => [
 						'post_lang_tokenizer' => [
-							'type'              => 'char_group',
-							'tokenize_on_chars' => [ ',' ],
+							'type'    => 'pattern',
+							'pattern' => ',',
 						],
 					],
 				],


### PR DESCRIPTION
Replace the char_group tokenizer with a pattern one, for wider Elasticsearch compatibility.

Ref: wpmlbridge-263