### PR TITLE
Fix crash on PHP >= 8.0.0

### DIFF
--- a/src/Traits/CrudPropagation.php
+++ b/src/Traits/CrudPropagation.php
@@ -200,7 +200,7 @@ trait CrudPropagation {
 	 */
 	private function combineIds( $role = 'main' ) {
 		$idsPerLanguage = $this->getIds( $role );
-		return array_unique( call_user_func_array( 'array_merge', $idsPerLanguage ) );
+		return array_unique( call_user_func_array( 'array_merge', array_values( $idsPerLanguage ) ) );
 	}
 
 	/**


### PR DESCRIPTION
It fixes #30 causing WordPress to crash on PHP >= 8.0.0.

This line causes the error `Uncaught ArgumentCountError: array_merge() does not accept unknown named parameters` which occurs when trashing or deleting a post:
```
return array_unique( call_user_func_array( 'array_merge', $idsPerLanguage ) );
```
Example of `$idsPerLanguage`:
```
$idsPerLanguage = [ 'en' => [ 1, 2 ], 'zh-hans' => [ 2 ] ];
```
Starting from PHP 8.0.0, if any keys of `$idsPerLanguage` are strings, those elements will be passed to `array_merge` as named arguments, with the name given by the key:
[call_user_func_array Changelog](https://www.php.net/manual/en/function.call-user-func-array.php#refsect1-function.call-user-func-array-changelog)

So `array_values` is needed to make it pass `$idsPerLanguage` values as positional arguments to `array_merge`:
[call_user_func_array Considerations](https://php.watch/versions/8.0/named-parameters#named-params-call_user_func_array)
```
return array_unique( call_user_func_array( 'array_merge', array_values( $idsPerLanguage ) ) );
```
