### PR TITLE
Fix: ElasticPress v5.0.0 API changes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           rm ./.gitignore ./.gitlab-ci.yml
           rm ./composer.* ./Makefile ./phpcs.* ./phpunit.xml ./run.sh
-          rm -Rf tests
+          rm -Rf tests .vscode
           find . -type d | grep '.git' | xargs rm -rf
 
       - name: Upload plugin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           rm ./.gitignore ./.gitlab-ci.yml
           rm ./composer.* ./Makefile ./phpcs.* ./phpunit.xml ./run.sh
-          rm -Rf tests
+          rm -Rf tests .vscode
           find . -type d | grep '.git' | xargs rm -rf
         working-directory: ./wpml-elasticpress
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ tests/wordpress
 Thumbs.db
 /tests/compatibility/*.txt
 .DS_Store
+.vscode
 
 inc/sandbox.inc
 *.sh

--- a/src/Sync/DashboardAjax.php
+++ b/src/Sync/DashboardAjax.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WPML\ElasticPress\Sync;
+
+use ElasticPress\Utils;
+
+use WPML\ElasticPress\Sync\Dashboard;
+
+/**
+ * Before ElasticPress 5.0.0 the Dashboard sync was run over AJAX.
+ */
+class DashboardAjax extends Dashboard {
+
+	public function addHooks() {
+		if ( 0 === count( $this->activeLanguages ) ) {
+			return;
+		}
+
+		add_action( 'wp_ajax_ep_index', [ $this, 'action_wp_ajax_ep_index' ], 9 );
+		add_action( 'wp_ajax_ep_cancel_index', [ $this, 'action_wp_ajax_ep_cancel_index' ], 9 );
+	}
+
+  private function isDashboardSync() {
+		if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) || ! EP_DASHBOARD_SYNC ) {
+			wp_send_json_error( null, 403 );
+			exit;
+		}
+
+		$index_meta = Utils\get_indexing_status();
+
+		if ( isset( $index_meta['method'] ) && 'cli' === $index_meta['method'] ) {
+			return false;
+		}
+
+		return true;
+	}
+
+  public function action_wp_ajax_ep_index() {
+		if ( false === $this->isDashboardSync() ) {
+			return;
+		}
+		$this->setUpAndRun();
+	}
+
+  public function action_wp_ajax_ep_cancel_index() {
+		if ( false === $this->isDashboardSync() ) {
+			return;
+		}
+		$this->tearDown();
+	}
+
+}

--- a/src/Sync/DashboardRest.php
+++ b/src/Sync/DashboardRest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace WPML\ElasticPress\Sync;
+
+use ElasticPress\Utils;
+
+use WPML\ElasticPress\Sync\Dashboard;
+
+/**
+ * After ElasticPress 5.0.0 the Dashboard sync was run over the REST API.
+ */
+class DashboardRest extends Dashboard {
+
+	public function addHooks() {
+		if ( 0 === count( $this->activeLanguages ) ) {
+			return;
+		}
+
+		add_filter( 'rest_request_before_callbacks', [ $this, 'rest_request_before_callbacks' ], 10, 3 ) ;
+	}
+
+	private function isSyncMethod( $method, $request ) {
+		if ( $method !== $request->get_method() ) {
+			return false;
+		}
+
+		$route = $request->get_route();
+		if ( preg_match( "/^\/elasticpress\/v\d+\/sync$/", $route ) ) {
+			return true;
+		}
+	
+		return false;
+	}
+
+	/**
+	 * @param  \WP_REST_Response|\WP_HTTP_Response|\WP_Error|mixed $response
+	 * @param  array                                               $handler
+	 * @param  \WP_REST_Request                                    $request
+	 *
+	 * @return \WP_REST_Response|\WP_HTTP_Response|\WP_Error|mixed
+	 */
+	public function rest_request_before_callbacks( $response, $handler, $request  ) {
+		$capability = Utils\get_capability();
+
+		if ( ! current_user_can( $capability ) ) {
+			return $response;
+		}
+		
+		if ( $this->isSyncMethod( 'POST', $request ) ) {
+			$this->setFullIndexArgs( $request->get_params() );
+			$this->setUpAndRun();
+		}
+
+		if ( $this->isSyncMethod( 'DELETE', $request ) ) {
+			$this->tearDown();
+		}
+
+		return $response;
+
+	}
+
+}


### PR DESCRIPTION
In ElasticPress 5.0.0 a couple of breaking changes were introduced:
- The Sync GUI moved from an AJAX resolution to a REST API one.
- The sync on posts save modified a public property adding a new layer for multisite support.

This PR adds support to those two compatibility changes.

Ref: wpmlbridge-288