### PR TITLE
Fix WPML\ElasticPress\Stats\Health::includeIndicesInHealthStats()

### DIFF
--- a/src/Stats/Health.php
+++ b/src/Stats/Health.php
@@ -60,7 +60,8 @@ class Health {
 		$indexable_sites = [];
 
 		if ( $this->networkActivated ) {
-			$indexable_sites = Utils\get_sites();
+			$indexable_sites = Utils\get_sites( 0, true );
+			$indexable_sites = wp_list_pluck( $indexable_sites, 'blog_id' );
 		};
 
 		$extraIndices = [];


### PR DESCRIPTION
The `includeIndicesInHealthStats()` method uses `$indexable_sites = Utils\get_sites()` to fetch a list of sites. It then incorrectly uses the list of sites in `foreach ( $indexable_sites as $indexableSiteId ) {..`, treating each item in `$indexable_sites` as the site ID. `$indexable_sites` is however a list of site objects, not site IDs.

This update:

- Adds the $only_indexable paramter to the `Utils\get_sites()` function call
- Uses `wp_list_pluck()` to turn the list of site objects into a list of site IDs