### PR TITLE
Update actions/upload-artifact to v4.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           find . -type d | grep '.git' | xargs rm -rf
 
       - name: Upload plugin
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wpml-elasticpress.${{ github.ref_name }}
           path: .


### PR DESCRIPTION
This should fix the errors in the last 2 builds - which are not entirely needed but simplify the mechanism to generate a new release.