### PR TITLE
Fix: Sync issue for Custom Search Results

### DIFF
--- a/src/Traits/CrudPropagation.php
+++ b/src/Traits/CrudPropagation.php
@@ -43,8 +43,8 @@ trait CrudPropagation {
 				$language = $this->defaultLanguage;
 			}
 
-			$this->mainIdsPerLanguage[ $language ]    = [];
-			$this->relatedIdsPerLanguage[ $language ] = [];
+			$this->mainIdsPerLanguage[ $language ]    ??= [];
+			$this->relatedIdsPerLanguage[ $language ] ??= [];
 
 			$this->registerObject( $object, $language );
 		}


### PR DESCRIPTION
Hi Team,

This is Burhan from the ElasticPress plugin team. We recently identified an issue where Custom Results were not working as expected.

Whenever a Custom Result is added or updated, the ElasticPress plugin needs to sync all posts that are added or reordered within that Custom Result. However, the add-on was only syncing one post from the list. This happened because the language-specific ID arrays ($mainIdsPerLanguage and $relatedIdsPerLanguage) were being reset to empty arrays during every loop iteration. As a result, previously stored post IDs were overwritten, and only the last post in each language was synced.

This PR fixes the issue by replacing the = operator with the ??= operator, so the arrays are initialized only once per language. This ensures that all previously added IDs are preserved and all posts are synced correctly.

