### PR TITLE
[wpmlbridge-355] Added check before initializing language array ids o…

### DIFF
--- a/src/Traits/CrudPropagation.php
+++ b/src/Traits/CrudPropagation.php
@@ -43,8 +43,12 @@ trait CrudPropagation {
 				$language = $this->defaultLanguage;
 			}
 
-			$this->mainIdsPerLanguage[ $language ]    = [];
-			$this->relatedIdsPerLanguage[ $language ] = [];
+			if ( ! isset( $this->mainIdsPerLanguage[ $language ] ) ) {
+				$this->mainIdsPerLanguage[ $language ] = [];
+			}
+			if ( ! isset( $this->relatedIdsPerLanguage[ $language ] ) ) {
+				$this->relatedIdsPerLanguage[ $language ] = [];
+			}
 
 			$this->registerObject( $object, $language );
 		}


### PR DESCRIPTION
Added check before initializing language array ids on propagateIds trait method.

Addressing: https://github.com/OnTheGoSystems/wpml-elasticpress/pull/66

Making it compatible with PHP 7.0

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlbridge-355