### PR TITLE
Fix: only delete the current site's indices on a fresh sync (#36)

### DIFF
--- a/src/Manager/Indices.php
+++ b/src/Manager/Indices.php
@@ -227,7 +227,14 @@ class Indices {
 	}
 
 	public function clearAllIndices() {
-		$this->elasticsearch->delete_all_indices();
+		$indexables = $this->indexables->get_all();
+		foreach ( $this->activeLanguages as $language ) {
+			$this->setCurrentIndexLanguage( $language );
+			foreach ( $indexables as $indexable ) {
+				$indexable->delete_index();
+			}
+			$this->clearCurrentIndexLanguage();
+		}
 		$this->clearClusterIndicesCache();
 	}
 

--- a/tests/phpstan/stubs/elasticpress.stub
+++ b/tests/phpstan/stubs/elasticpress.stub
@@ -185,6 +185,12 @@ namespace ElasticPress {
 		public function get_index_name( $blog_id = null ) {}
 
 		/**
+		 * @param  int $blog_id `null` means current blog.
+		 * @return boolean
+		 */
+		public function delete_index( $blog_id = null ) {}
+
+		/**
 		 * @return array
 		 */
 		public function get_indexable_post_status() {}


### PR DESCRIPTION
 Fixes #36.

  ## Problem
  `Indices::clearAllIndices()` calls ElasticPress's `Elasticsearch::delete_all_indices()`,
  which is just `delete_index( '*' )` — i.e. `DELETE {host}/*`. On a shared Elasticsearch
  cluster this deletes **every** index, including those belonging to other, unrelated sites.

  So clicking **"Delete all Data and Start a Fresh Sync"** in the dashboard (or running the
  CLI regenerate path) on one site wipes the indexed data of every other site on the same
  cluster — the behaviour reported in #36.

  ## Fix
  Delete only *this* site's indices. Iterate the active WPML languages and, for each
  indexable, call `Indexable::delete_index()`:

  ```php
  public function clearAllIndices() {
      $indexables = $this->indexables->get_all();
      foreach ( $this->activeLanguages as $language ) {
          $this->setCurrentIndexLanguage( $language );
          foreach ( $indexables as $indexable ) {
              $indexable->delete_index();
          }
          $this->clearCurrentIndexLanguage();
      }
      $this->clearClusterIndicesCache();
  }
```
  Why this is correct and safe:

  - Structural mirror of generateMissingIndices() — it iterates the exact same
  activeLanguages × indexables->get_all() set, so by construction it deletes precisely
  the indices this plugin creates. It also matches the per-language/per-indexable pattern
  already used in deleteBlogLanguageIndices().
  - Indexable::delete_index() resolves the index name through get_index_name(), which
  applies the ep_index_name filter — the plugin's existing filterIndexName() adds the
  -<lang> suffix — and EP's per-site name prefix (<site-host>-<slug>-<blog_id>) keeps
  every delete scoped to this install. It never targets *.
  - Indexable::delete_index() is @ since 3.0, so it exists on every EP version this plugin
  supports. Elasticsearch::delete_index() treats a 404 as success, so a not-yet-created
  per-language index during a fresh sync no-ops cleanly instead of erroring.
  - Both call sites (Sync\Dashboard::maybePutMapping() and Sync\CLI::regenerateIndices())
  immediately follow with generateMissingIndices(), which manages the current-index
  language itself — so the end state is unchanged.

  Also adds the ElasticPress\Indexable::delete_index() signature to the PHPStan stub so
  static analysis recognises the call.

  On multisite this also removes a second, latent data-loss path: the sync runs with
  network_wide => 0 (current site only), so the old cluster-wide delete removed other
  sites' indices and then never resynced them. Scoping the delete to the current site makes
  the wipe self-consistent with what the fresh sync recreates.

  Verification

  Run under PHP 7.4 (the CI version):
  - PHPUnit: passes (the suite currently contains no tests — exit 0).
  - PHPStan (level 3): clean, no errors.
  - PHP 7.4+ compatibility (phpcs.compatibility.xml): clean.
  - WordPress-Core PHPCS style is not run by GitHub CI (which runs PHPUnit + PHPStan); the
  change follows the surrounding code style exactly and adds no new style category.

  Out of scope (possible follow-up)

  delete_index() does not remove EP's network/global alias. Deleting an index drops any
  single-index alias entry automatically, so this isn't required to fix the data-loss bug,
  but a multisite global-alias cleanup could be added separately if desired.