### PR TITLE
Fx: skip index existence checks on singular post sync

### DIFF
--- a/src/Traits/CrudPropagation.php
+++ b/src/Traits/CrudPropagation.php
@@ -178,7 +178,6 @@ trait CrudPropagation {
 			return;
 		}
 
-		$this->indicesManager->generateIndexByIndexable( $postIndexable );
 		$postIndexable->bulk_index_dynamically( $ids );
 	}
 
@@ -193,20 +192,11 @@ trait CrudPropagation {
 			return [];
 		}
 
-		$indexName = $postIndexable->get_index_name();
-		if ( ! $this->indicesManager->indexExists( $indexName ) ) {
-			return [];
+		foreach ( $ids as $id ) {
+			$postIndexable->delete( $id );
 		}
-		return array_values(
-			array_filter( $ids, function( $id ) use ( $postIndexable ) {
-				// Skip docs that do not exist in the current index
-				if ( false === $postIndexable->get( $id ) ) {
-					return false;
-				}
-				$postIndexable->delete( $id );
-				return true;
-			} )
-		);
+
+		return array_values( $ids );
 	}
 
 	/**


### PR DESCRIPTION
## Description

On every post save, the WPML ElasticPress add-on runs `syncIds()` and `deleteIds()`. Both paths previously called `indexExists()`, which fetches the full cluster index list via Elasticsearch `_cat/indices`. That extra round-trip slows down singular post saves and is unnecessary: if the target index is missing, the index/delete request fails naturally and ElasticPress logs the error in its status report.

`syncIds()` also went through `generateIndexByIndexable()`, which could create a language index on the fly during an individual post sync. Indices should only be created during a full sync. Mapping changes belong on hooks like `ep_post_mapping`, not in singular sync.

## Summary
- Remove the `generateIndexByIndexable()` call from `syncIds()` so singular post saves no longer run `indexExists()` or create indices on the fly.
- Simplify `deleteIds()` to call `$postIndexable->delete( $id )` directly, without `indexExists()` or a per-document `get()` check.
- Index creation remains limited to full sync flows (Dashboard/CLI via `generateMissingIndices()`).

Fixes https://github.com/OnTheGoSystems/wpml-elasticpress/issues/69