### PR TITLE
Add CJK analyzer support for Chinese, Japanese and Korean

### DIFF
--- a/src/Traits/TranslateLanguages.php
+++ b/src/Traits/TranslateLanguages.php
@@ -18,6 +18,7 @@ trait TranslateLanguages {
 		'brazilian'  => [ 'pt-br' ],
 		'bulgarian'  => [ 'bg' ],
 		'catalan'    => [ 'ca' ],
+		'cjk'        => [ 'zh-hans', 'zh-hant', 'ja', 'ko' ],
 		'czech'      => [ 'cs' ],
 		'danish'     => [ 'da' ],
 		'dutch'      => [ 'nl' ],


### PR DESCRIPTION
References #56 (choosing the correct language analyzer).

## Problem
The analyzer map in `TranslateLanguages` has no entry for Chinese, Japanese or Korean, so `generateAnalysisLanguages()` falls back to the `english` analyzer for `zh-hans`, `zh-hant`, `ja` and `ko` indices. CJK text has no word separators, so standard tokenization turns whole sentences into single tokens and search on those languages is effectively broken.

## Fix
One line: map those four WPML language codes to Elasticsearch's built-in `cjk` analyzer, which tokenizes CJK text into overlapping bigrams.

Everything downstream works through the existing wiring, unchanged:
- **Stopwords:** `generateIndexByIndexable()` builds the stopword list as `'_' . analyzer . '_'` → `_cjk_`, which is one of Elasticsearch's predefined
  stopword lists.
- **Snowball:** `cjk` is not in `$snowballLanguages`, so the snowball filter keeps its default — the same path Arabic and Thai already take.
- **Stemmer:** `cjk` is not in `$stemmerLanguages`, so no stemmer filter is added — no stemmer exists for these languages (again like Arabic/Thai; see also the Thai stemmer fix in 2.0.5).

## Verification
- PHPStan (level 3): clean.
- PHPUnit suite: passes.
- `cjk` analyzer and `_cjk_` stopword list verified against the Elasticsearch built-in language analyzer / stop filter references.