### PR TITLE
Add first unit tests for language analysis and guid language detection

### DIFF
--- a/tests/phpunit/FieldLanguagePatternTest.php
+++ b/tests/phpunit/FieldLanguagePatternTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use WPML\ElasticPress\Field\Sync;
+
+class FieldLanguagePatternTestDouble extends Sync {
+	public function callBuildLanguagePattern() {
+		return $this->buildLanguagePattern();
+	}
+}
+
+class FieldLanguagePatternTest extends OTGS_TestCase {
+
+	public function guidProvider() {
+		return [
+			'language as directory'   => [ 'http://example.com/de/some-post/', 'de' ],
+			'language as parameter'   => [ 'http://example.com/?p=1&lang=fr', 'fr' ],
+			'language as subdomain'   => [ 'http://de.example.com/some-post/', 'de' ],
+			'default language guid'   => [ 'http://example.com/some-post/', null ],
+			'unrelated language code' => [ 'http://example.com/it/some-post/', null ],
+		];
+	}
+
+	/**
+	 * @dataProvider guidProvider
+	 *
+	 * @param string      $guid
+	 * @param string|null $expectedLanguage
+	 */
+	public function test_pattern_extracts_language_from_guid( $guid, $expectedLanguage ) {
+		$subject = new FieldLanguagePatternTestDouble( '7.10', [ 'en', 'de', 'fr' ], 'en', 'en' );
+
+		$pattern = $subject->callBuildLanguagePattern();
+		$matched = preg_match( $pattern, $guid, $match );
+
+		if ( null === $expectedLanguage ) {
+			$this->assertSame( 0, $matched );
+			return;
+		}
+
+		$this->assertSame( 1, $matched );
+		// getPostLanguage() reads the last captured group.
+		$this->assertSame( $expectedLanguage, end( $match ) );
+	}
+}

--- a/tests/phpunit/TranslateLanguagesTest.php
+++ b/tests/phpunit/TranslateLanguagesTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use WPML\ElasticPress\Traits\TranslateLanguages;
+
+class TranslateLanguagesTestDouble {
+	use TranslateLanguages;
+
+	public function callGenerateAnalysisLanguages( $languageCode ) {
+		return $this->generateAnalysisLanguages( $languageCode );
+	}
+
+	public function callLanguageHasStemmer( $language ) {
+		return $this->languageHasStemmer( $language );
+	}
+}
+
+class TranslateLanguagesTest extends OTGS_TestCase {
+
+	public function analysisLanguagesProvider() {
+		return [
+			'german has analyzer and snowball' => [ 'de', 'german', 'German' ],
+			'english is fully supported'       => [ 'en', 'english', 'English' ],
+			'arabic has no snowball'           => [ 'ar', 'arabic', 'English' ],
+			'thai has no snowball'             => [ 'th', 'thai', 'English' ],
+			'brazilian portuguese maps'        => [ 'pt-br', 'brazilian', 'English' ],
+			'norwegian nynorsk maps'           => [ 'nn', 'norwegian', 'Norwegian' ],
+			'unknown falls back to english'    => [ 'xx', 'english', 'English' ],
+		];
+	}
+
+	/**
+	 * @dataProvider analysisLanguagesProvider
+	 *
+	 * @param string $languageCode
+	 * @param string $expectedAnalyzer
+	 * @param string $expectedSnowball
+	 */
+	public function test_generate_analysis_languages( $languageCode, $expectedAnalyzer, $expectedSnowball ) {
+		$subject = new TranslateLanguagesTestDouble();
+
+		$this->assertSame(
+			[
+				'analyzer' => $expectedAnalyzer,
+				'snowball' => $expectedSnowball,
+			],
+			$subject->callGenerateAnalysisLanguages( $languageCode )
+		);
+	}
+
+	public function test_language_has_stemmer() {
+		$subject = new TranslateLanguagesTestDouble();
+
+		$this->assertTrue( $subject->callLanguageHasStemmer( 'german' ) );
+		$this->assertTrue( $subject->callLanguageHasStemmer( 'arabic' ) );
+		$this->assertFalse( $subject->callLanguageHasStemmer( 'thai' ) );
+		$this->assertFalse( $subject->callLanguageHasStemmer( 'unknown' ) );
+	}
+}


### PR DESCRIPTION
## What
The PHPUnit suite currently contains no tests (CI reports "No tests executed"). This adds the first two test files, covering the two pieces of pure logic in the plugin that need no WordPress mocks:

- **`TranslateLanguagesTest`** — `generateAnalysisLanguages()` and `languageHasStemmer()`: analyzer/snowball resolution for fully-supported languages (de, en), languages without snowball support (ar, th, pt-br), multi-code languages (nn → norwegian), and the english fallback for unknown codes; stemmer availability including the no-stemmer languages.
- **`FieldLanguagePatternTest`** — `buildLanguagePattern()`: language extraction from post guids for all three URL formats the pattern supports (directory `/de/`, query parameter `?lang=fr`, subdomain `de.`), plus non-matching guids, asserting the last-captured-group convention that `getPostLanguage()` relies on.

## Notes
- Test doubles are small named classes (a trait host and a `Field\Sync` subclass) rather than anonymous classes, because the test framework's include rewriting does not parse anonymous classes.
- No production code is touched.

## Verification
- PHPUnit under PHP 7.4 (CI version): **13 tests, 19 assertions, OK**.
- PHPStan (level 3): clean.