### PR TITLE
Log index deletion failures during a fresh sync

### DIFF
--- a/src/Manager/Indices.php
+++ b/src/Manager/Indices.php
@@ -231,7 +231,10 @@ class Indices {
 		foreach ( $this->activeLanguages as $language ) {
 			$this->setCurrentIndexLanguage( $language );
 			foreach ( $indexables as $indexable ) {
-				$indexable->delete_index();
+				if ( false === $indexable->delete_index() && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					// A surviving index is skipped by generateMissingIndices() and keeps stale data.
+					error_log( 'WPML ElasticPress: could not delete index ' . $indexable->get_index_name() );
+				}
 			}
 			$this->clearCurrentIndexLanguage();
 		}


### PR DESCRIPTION
Small follow-up to #70.

## Problem
`clearAllIndices()` ignores the return value of `Indexable::delete_index()`. If a deletion fails (network error, permissions, ES 5xx), the index survives, `generateMissingIndices()` then skips it as already existing, and the "Delete all Data and Start a Fresh Sync" run silently indexes into stale data with the old mapping — with nothing anywhere explaining why the reset didn't
reset.

## Fix
When `delete_index()` returns `false` and `WP_DEBUG` is enabled, log the affected index name:
```
php
if ( false === $indexable->delete_index() && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
    // A surviving index is skipped by generateMissingIndices() and keeps stale data.
    error_log( 'WPML ElasticPress: could not delete index ' . $indexable->get_index_name() );
}
```

Deliberately minimal: debug-gated, no new logging infrastructure, no behavior change for the success path. (`Elasticsearch::delete_index()` treats HTTP 404 as success, so a not-yet-created index does not trigger the log.)

## Verification
- PHPStan (level 3): clean.
- PHPUnit suite: passes.