### PR TITLE
[wpmlbridge-352] Prepare WPML ElasticPress 3.0 for the WPML 5.0 release

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: Add full WPML support for ElasticPress.
  * Author: OnTheGoSystems
  * Author URI: http://www.onthegosystems.com/
- * Version: 2.1.0
+ * Version: 3.0
  * Plugin Slug: wpmlelasticpress
  *
  * @package wpml/bridge/elasticpress
@@ -33,7 +33,7 @@ if ( defined( 'WPMLELASTICPRESS_VERSION' ) ) {
 	return;
 }
 
-define( 'WPMLELASTICPRESS_VERSION', '2.1.0' );
+define( 'WPMLELASTICPRESS_VERSION', '3.0' );
 define( 'WPMLELASTICPRESS_PLUGIN_PATH', dirname( __FILE__ ) );
 
 require_once WPMLELASTICPRESS_PLUGIN_PATH . '/vendor/autoload.php';

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,22 @@ class Plugin {
 	// After ElasticPress 5.0.0, the Dashboard sync is run over the REST API.
 	const DASHBOARD_SYNC_API_CHANGE_V1 = '5.0.0';
 
+	/**
+	 * Checks the WPML version against wpml-dependencies.json.
+	 *
+	 * WPML core declares WPML_Core_Version_Check and loads before
+	 * "plugins_loaded" priority 11, so the class is available here.
+	 *
+	 * @return bool
+	 */
+	private static function hasSupportedCore() {
+		if ( ! class_exists( 'WPML_Core_Version_Check' ) ) {
+			return false;
+		}
+
+		return \WPML_Core_Version_Check::is_ok( WPMLELASTICPRESS_PLUGIN_PATH . '/wpml-dependencies.json' );
+	}
+
 	public static function init() {
 		add_action( 'plugins_loaded', function () {
 			if ( ! defined( 'EP_VERSION' ) || version_compare( EP_VERSION, '3.0.0', '<' ) ) {
@@ -19,6 +35,10 @@ class Plugin {
 			}
 
 			if ( ! defined( 'ICL_SITEPRESS_VERSION' ) ) {
+				return;
+			}
+
+			if ( ! self::hasSupportedCore() ) {
 				return;
 			}
 

--- a/tests/phpstan/bootstrap.php
+++ b/tests/phpstan/bootstrap.php
@@ -1,3 +1,4 @@
 <?php
 define( 'EP_VERSION', '5.6.7' );
 define( 'EP_DASHBOARD_SYNC', false );
+define( 'WPMLELASTICPRESS_PLUGIN_PATH', dirname( __DIR__, 2 ) );

--- a/wpml-dependencies.json
+++ b/wpml-dependencies.json
@@ -1,0 +1,3 @@
+{
+  "sitepress-multilingual-cms": "5.0"
+}


### PR DESCRIPTION
Sets the plugin version to 3.0 and adds a WPML 5.0 requirement.

The plugin had no wpml-dependencies.json and no version check. The check runs in the existing `plugins_loaded` callback, so it needs no new composer dependency.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlbridge-352/