### PR TITLE
Validate the search language at query time and route admin-ajax handlers through a policy adapter

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
     - tests/phpstan/bootstrap.php
     - tests/phpstan/stubs/elasticpress.stub
     - tests/phpstan/stubs/wp-cli.stub
+    - tests/phpstan/stubs/wpml-request-policy.stub
   paths:
     - src
   dynamicConstantNames:

--- a/src/Field/Search.php
+++ b/src/Field/Search.php
@@ -73,12 +73,32 @@ class Search extends Field {
 		if (
 			isset( $_GET['lang'] )
 			&& is_string( $_GET['lang'] )
-			&& in_array( $_GET['lang'], $this->activeLanguages, true )
+			&& $this->isViewerVisibleLanguage( $_GET['lang'] )
 		) {
 			$lang = $_GET['lang'];
 		}
 
 		return $lang;
+	}
+
+	/**
+	 * Whether the current viewer may select this language for searching.
+	 *
+	 * `$this->activeLanguages` is resolved at plugins_loaded, before `init`, when
+	 * WPML's show_hidden() is still true for every request, so it contains hidden
+	 * languages regardless of the viewer. That set is the right one for indexing.
+	 * For a requester-selected search language, resolve the viewer-sensitive
+	 * active-language set at query time instead: hidden languages are only
+	 * present when Core's show_hidden() policy allows this viewer to see them.
+	 *
+	 * @param string $lang
+	 *
+	 * @return bool
+	 */
+	private function isViewerVisibleLanguage( $lang ) {
+		$viewerLanguages = array_keys( (array) apply_filters( 'wpml_active_languages', [] ) );
+
+		return in_array( $lang, $viewerLanguages, true );
 	}
 
 }

--- a/src/Request/Ajax.php
+++ b/src/Request/Ajax.php
@@ -3,7 +3,7 @@
 namespace WPML\ElasticPress\Request;
 
 /**
- * Request-policy adapter for this plugin's admin-ajax handlers (wpmldev-7976).
+ * Request-policy adapter for this plugin's admin-ajax handlers.
  *
  * Every handler this plugin binds to `wp_ajax_*` / `wp_ajax_nopriv_*` goes
  * through here with a declarative policy spec, never through a raw

--- a/src/Request/Ajax.php
+++ b/src/Request/Ajax.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace WPML\ElasticPress\Request;
+
+/**
+ * Request-policy adapter for this plugin's admin-ajax handlers (wpmldev-7976).
+ *
+ * Every handler this plugin binds to `wp_ajax_*` / `wp_ajax_nopriv_*` goes
+ * through here with a declarative policy spec, never through a raw
+ * `add_action()`. With WPML core's request-policy model available the spec
+ * becomes a \WPML\Request\Policy\Policy registered through
+ * \WPML\Request\Adapter\Ajax, so the core dispatch gate enforces it (and
+ * detaches anything bound without one). Against an older core that lacks
+ * the model, the handler is registered as before and keeps relying on its
+ * own inline checks - the fallback exists so this plugin never fatals on a
+ * core it is not paired with, not as a second policy engine.
+ *
+ * Spec keys (exactly one authorization key, plus one authenticity key):
+ *   'capability'    => string|string[]  any-of; administrators always pass
+ *   'authorize'     => callable, 'description' => string   (literal true allows)
+ *   'authenticated' => string (reason)  any logged-in user, scoped to the caller
+ *   'public'        => string (reason)  anyone, incl. anonymous (nopriv registered)
+ *   'machine'       => callable, 'description' => string   credential verifier
+ *   'nonce'         => [ string $action, string|string[] $field ]
+ *   'no_nonce'      => string (reason)
+ */
+final class Ajax {
+
+	/**
+	 * @param string   $action
+	 * @param array    $spec
+	 * @param callable $callback
+	 * @param int      $priority
+	 * @param int      $acceptedArgs
+	 *
+	 * @return void
+	 */
+	public static function register( $action, array $spec, callable $callback, $priority = 10, $acceptedArgs = 1 ) {
+		if ( self::coreAvailable() ) {
+			\WPML\Request\Adapter\Ajax::register( $action, self::policy( $spec, $action ), $callback, $priority, $acceptedArgs );
+
+			return;
+		}
+
+		add_action( 'wp_ajax_' . $action, $callback, $priority, $acceptedArgs );
+		if ( isset( $spec['public'] ) || isset( $spec['machine'] ) ) {
+			add_action( 'wp_ajax_nopriv_' . $action, $callback, $priority, $acceptedArgs );
+		}
+	}
+
+	/**
+	 * Ride a third-party host action: the host enforces its own policy; the
+	 * callback only adjusts this plugin's context for that request.
+	 *
+	 * @param string   $hostAction
+	 * @param callable $callback
+	 * @param string   $reason
+	 * @param int      $priority
+	 * @param int      $acceptedArgs
+	 * @param bool     $alsoNopriv
+	 *
+	 * @return void
+	 */
+	public static function listen( $hostAction, callable $callback, $reason, $priority = 10, $acceptedArgs = 1, $alsoNopriv = false ) {
+		if ( self::coreAvailable() ) {
+			\WPML\Request\Adapter\Ajax::listen( $hostAction, $callback, $reason, $priority, $acceptedArgs, $alsoNopriv );
+
+			return;
+		}
+
+		add_action( 'wp_ajax_' . $hostAction, $callback, $priority, $acceptedArgs );
+		if ( $alsoNopriv ) {
+			add_action( 'wp_ajax_nopriv_' . $hostAction, $callback, $priority, $acceptedArgs );
+		}
+	}
+
+	/**
+	 * @return bool
+	 */
+	public static function coreAvailable() {
+		static $available = null;
+
+		if ( null === $available ) {
+			$available = class_exists( '\WPML\Request\Adapter\Ajax' ) && class_exists( '\WPML\Request\Policy\Policy' );
+			if ( $available ) {
+				// Tell the core gate which files are ours, so a handler this
+				// plugin binds without a policy is detached like a core one.
+				\WPML\Request\Policy\Registry::ownRoot( dirname( dirname( __DIR__ ) ) );
+			}
+		}
+
+		return $available;
+	}
+
+	/**
+	 * @param array  $spec
+	 * @param string $action
+	 *
+	 * @return \WPML\Request\Policy\Policy
+	 */
+	public static function policy( array $spec, $action ) {
+		if ( isset( $spec['nonce'] ) && is_array( $spec['nonce'] ) ) {
+			$authenticity = \WPML\Request\Policy\Authenticity::actionNonce( $spec['nonce'][0], isset( $spec['nonce'][1] ) ? $spec['nonce'][1] : 'nonce' );
+		} elseif ( isset( $spec['machine'] ) ) {
+			$authenticity = null;
+		} else {
+			$authenticity = \WPML\Request\Policy\Authenticity::none( isset( $spec['no_nonce'] ) ? (string) $spec['no_nonce'] : '' );
+		}
+
+		if ( isset( $spec['capability'] ) ) {
+			return \WPML\Request\Policy\Policy::capability( $spec['capability'], $authenticity );
+		}
+		if ( isset( $spec['authorize'] ) ) {
+			return \WPML\Request\Policy\Policy::authorize( $spec['authorize'], $authenticity, isset( $spec['description'] ) ? $spec['description'] : '' );
+		}
+		if ( isset( $spec['authenticated'] ) ) {
+			return \WPML\Request\Policy\Policy::authenticated( $authenticity, (string) $spec['authenticated'] );
+		}
+		if ( isset( $spec['public'] ) ) {
+			return \WPML\Request\Policy\Policy::publicAccess( (string) $spec['public'], $authenticity );
+		}
+		if ( isset( $spec['machine'] ) ) {
+			return \WPML\Request\Policy\Policy::machine( $spec['machine'], isset( $spec['description'] ) ? $spec['description'] : '' );
+		}
+
+		// Unknown spec: a policy that denies (fail closed), never an open handler.
+		return \WPML\Request\Policy\Policy::authorize(
+			function () {
+				return false;
+			},
+			\WPML\Request\Policy\Authenticity::none( 'malformed policy spec' ),
+			'fail-closed: malformed policy spec for ' . $action
+		);
+	}
+}

--- a/src/Sync/DashboardAjax.php
+++ b/src/Sync/DashboardAjax.php
@@ -16,12 +16,32 @@ class DashboardAjax extends Dashboard {
 			return;
 		}
 
-		add_action( 'wp_ajax_ep_index', [ $this, 'action_wp_ajax_ep_index' ], 9 );
-		add_action( 'wp_ajax_ep_cancel_index', [ $this, 'action_wp_ajax_ep_cancel_index' ], 9 );
+		// wpmldev-7976: these ride ElasticPress's own dashboard-sync actions at
+		// priority 9 and take the request over (they answer and exit), so the
+		// host's capability check at priority 10 never runs - isDashboardSync()
+		// therefore enforces ElasticPress's own sync capability itself, as the
+		// REST twin (DashboardRest) already does.
+		\WPML\ElasticPress\Request\Ajax::listen(
+			'ep_index',
+			[ $this, 'action_wp_ajax_ep_index' ],
+			'ElasticPress dashboard sync: per-language index run; verifies the ep_dashboard_nonce and ElasticPress\Utils\get_capability() itself',
+			9
+		);
+		\WPML\ElasticPress\Request\Ajax::listen(
+			'ep_cancel_index',
+			[ $this, 'action_wp_ajax_ep_cancel_index' ],
+			'ElasticPress dashboard sync cancel: verifies the ep_dashboard_nonce and ElasticPress\Utils\get_capability() itself',
+			9
+		);
 	}
 
   private function isDashboardSync() {
 		if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) || ! EP_DASHBOARD_SYNC ) {
+			wp_send_json_error( null, 403 );
+			exit;
+		}
+
+		if ( ! current_user_can( Utils\get_capability() ) ) {
 			wp_send_json_error( null, 403 );
 			exit;
 		}

--- a/src/Sync/DashboardAjax.php
+++ b/src/Sync/DashboardAjax.php
@@ -16,11 +16,10 @@ class DashboardAjax extends Dashboard {
 			return;
 		}
 
-		// wpmldev-7976: these ride ElasticPress's own dashboard-sync actions at
-		// priority 9 and take the request over (they answer and exit), so the
-		// host's capability check at priority 10 never runs - isDashboardSync()
-		// therefore enforces ElasticPress's own sync capability itself, as the
-		// REST twin (DashboardRest) already does.
+		// These ride ElasticPress's own dashboard-sync actions at priority 9 and
+		// answer the request themselves, so isDashboardSync() checks
+		// ElasticPress's own sync capability directly, as DashboardRest already
+		// does.
 		\WPML\ElasticPress\Request\Ajax::listen(
 			'ep_index',
 			[ $this, 'action_wp_ajax_ep_index' ],

--- a/src/Sync/DashboardAjax.php
+++ b/src/Sync/DashboardAjax.php
@@ -40,7 +40,11 @@ class DashboardAjax extends Dashboard {
 			exit;
 		}
 
-		if ( ! current_user_can( Utils\get_capability() ) ) {
+		// ElasticPress added get_capability() in 4.5.0. This AJAX sync serves every
+		// version below 5.0.0, so older ones fall back to the administrator capability.
+		$capability = function_exists( 'ElasticPress\Utils\get_capability' ) ? Utils\get_capability() : 'manage_options';
+
+		if ( ! current_user_can( $capability ) ) {
 			wp_send_json_error( null, 403 );
 			exit;
 		}

--- a/tests/phpstan/stubs/wpml-request-policy.stub
+++ b/tests/phpstan/stubs/wpml-request-policy.stub
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * WPML core request-policy model, consumed by src/Request/Ajax.php when the
+ * paired core provides it. Signatures mirror sitepress-multilingual-cms
+ * classes/request/{adapter,policy}.
+ */
+
+namespace WPML\Request\Adapter {
+
+	final class Ajax {
+
+		/**
+		 * @param string                      $action
+		 * @param \WPML\Request\Policy\Policy $policy
+		 * @param callable                    $callback
+		 * @param int                         $priority
+		 * @param int                         $acceptedArgs
+		 */
+		public static function register( $action, \WPML\Request\Policy\Policy $policy, callable $callback, $priority = 10, $acceptedArgs = 1 ): void {}
+
+		/**
+		 * @param string   $hostAction
+		 * @param callable $callback
+		 * @param string   $reason
+		 * @param int      $priority
+		 * @param int      $acceptedArgs
+		 * @param bool     $alsoNopriv
+		 */
+		public static function listen( $hostAction, callable $callback, $reason, $priority = 10, $acceptedArgs = 1, $alsoNopriv = false ): void {}
+
+	}
+
+}
+
+namespace WPML\Request\Policy {
+
+	final class Registry {
+
+		/**
+		 * @param string $path
+		 */
+		public static function ownRoot( $path ): void {}
+
+	}
+
+	final class Authenticity {
+
+		/**
+		 * @param string          $action
+		 * @param string|string[] $fields
+		 */
+		public static function actionNonce( $action, $fields = 'nonce' ): self {}
+
+		/**
+		 * @param string $reason
+		 */
+		public static function none( $reason ): self {}
+
+	}
+
+	final class Policy {
+
+		/**
+		 * @param string|string[] $capabilities
+		 */
+		public static function capability( $capabilities, Authenticity $authenticity ): self {}
+
+		/**
+		 * @param string $reason
+		 */
+		public static function authenticated( Authenticity $authenticity, $reason ): self {}
+
+		/**
+		 * @param string $description
+		 */
+		public static function authorize( callable $decider, Authenticity $authenticity, $description ): self {}
+
+		/**
+		 * @param string $reason
+		 */
+		public static function publicAccess( $reason, ?Authenticity $authenticity = null ): self {}
+
+		/**
+		 * @param string $reason
+		 */
+		public static function machine( callable $verifier, $reason ): self {}
+
+	}
+
+}

--- a/tests/phpunit/tests/Field/SearchTest.php
+++ b/tests/phpunit/tests/Field/SearchTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace WPML\ElasticPress\Field;
+
+/**
+ * @group field
+ * @group search
+ */
+class SearchTest extends \OTGS_TestCase {
+
+	const ES_VERSION = '7.10';
+
+	/**
+	 * The language set resolved at plugins_loaded, before `init`, when WPML's
+	 * show_hidden() is still true for every request. It always contains the
+	 * hidden languages, whoever the viewer is.
+	 */
+	const PRE_INIT_LANGUAGES = [ 'en', 'fr', 'de' ];
+
+	public function setUp(): void {
+		parent::setUp();
+		unset( $_GET['lang'] );
+	}
+
+	public function tearDown(): void {
+		unset( $_GET['lang'] );
+		parent::tearDown();
+	}
+
+	private function getSubject( $currentLanguage = 'en' ) {
+		return new Search( self::ES_VERSION, self::PRE_INIT_LANGUAGES, 'en', $currentLanguage );
+	}
+
+	/**
+	 * Mock the viewer-sensitive active-language set resolved at query time,
+	 * after `init`: hidden languages are only present when Core's show_hidden()
+	 * policy allows this viewer to see them.
+	 */
+	private function mockViewerVisibleLanguages( array $codes ) {
+		\WP_Mock::onFilter( 'wpml_active_languages' )
+			->with( [] )
+			->reply( array_fill_keys( $codes, [] ) );
+	}
+
+	private function filteredLanguage( Search $subject ) {
+		$args = $subject->filterByLanguage( [] );
+
+		return $args['post_filter']['bool']['must'][0]['term']['post_lang'];
+	}
+
+	/**
+	 * @test
+	 *
+	 * `fr` is in the pre-`init` constructor language set (which always includes
+	 * hidden languages), but the viewer-sensitive set at query time does not
+	 * contain it. The request-selected language must be rejected and the search
+	 * stays in the current language.
+	 */
+	public function itRejectsARequestSelectedLanguageTheViewerCannotSee() {
+		$_GET['lang'] = 'fr';
+		$this->mockViewerVisibleLanguages( [ 'en', 'de' ] );
+
+		$this->assertSame( 'en', $this->filteredLanguage( $this->getSubject( 'en' ) ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itAcceptsARequestSelectedViewerVisibleLanguage() {
+		$_GET['lang'] = 'de';
+		$this->mockViewerVisibleLanguages( [ 'en', 'de' ] );
+
+		$this->assertSame( 'de', $this->filteredLanguage( $this->getSubject( 'en' ) ) );
+	}
+
+	/**
+	 * @test
+	 *
+	 * Positive control: when Core's show_hidden() policy makes the hidden
+	 * language visible to this viewer, the query-time set contains it and the
+	 * selection is honored.
+	 */
+	public function itAcceptsAHiddenLanguageWhenCoreShowsHiddenToThisViewer() {
+		$_GET['lang'] = 'fr';
+		$this->mockViewerVisibleLanguages( [ 'en', 'fr', 'de' ] );
+
+		$this->assertSame( 'fr', $this->filteredLanguage( $this->getSubject( 'en' ) ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itRejectsANonexistentLanguage() {
+		$_GET['lang'] = 'xx';
+		$this->mockViewerVisibleLanguages( [ 'en', 'de' ] );
+
+		$this->assertSame( 'en', $this->filteredLanguage( $this->getSubject( 'en' ) ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itRejectsANonStringLanguage() {
+		$_GET['lang'] = [ 'fr' ];
+		$this->mockViewerVisibleLanguages( [ 'en', 'fr', 'de' ] );
+
+		$this->assertSame( 'en', $this->filteredLanguage( $this->getSubject( 'en' ) ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itUsesTheCurrentLanguageWithoutARequestSelection() {
+		$this->mockViewerVisibleLanguages( [ 'en', 'de' ] );
+
+		$this->assertSame( 'de', $this->filteredLanguage( $this->getSubject( 'de' ) ) );
+	}
+}

--- a/tests/phpunit/tests/Request/RequestPolicyCoverageTest.php
+++ b/tests/phpunit/tests/Request/RequestPolicyCoverageTest.php
@@ -3,14 +3,13 @@
 namespace WPML\ElasticPress\Request;
 
 /**
- * Architectural regression for wpmldev-7976: every admin-ajax / admin-post /
- * REST / XML-RPC binding in this plugin goes through the request-policy
- * adapter (`WPML\ElasticPress\Request\Ajax`), never through a raw registration. The universe is
- * the plugin's own PHP tree; a new handler bound without a policy fails here.
+ * Architectural test: every admin-ajax / admin-post / REST / XML-RPC binding
+ * in this plugin goes through the request-policy adapter
+ * (`WPML\ElasticPress\Request\Ajax`), never through a raw registration. The
+ * universe is the plugin's own PHP tree; a new handler bound without a policy
+ * fails here.
  *
  * @group request-policy
- * @group security
- * @group wpmldev-7976
  */
 class RequestPolicyCoverageTest extends \PHPUnit\Framework\TestCase {
 

--- a/tests/phpunit/tests/Request/RequestPolicyCoverageTest.php
+++ b/tests/phpunit/tests/Request/RequestPolicyCoverageTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace WPML\ElasticPress\Request;
+
+/**
+ * Architectural regression for wpmldev-7976: every admin-ajax / admin-post /
+ * REST / XML-RPC binding in this plugin goes through the request-policy
+ * adapter (`WPML\ElasticPress\Request\Ajax`), never through a raw registration. The universe is
+ * the plugin's own PHP tree; a new handler bound without a policy fails here.
+ *
+ * @group request-policy
+ * @group security
+ * @group wpmldev-7976
+ */
+class RequestPolicyCoverageTest extends \PHPUnit\Framework\TestCase {
+
+	const SHIM = 'src/Request/Ajax.php';
+
+	/** Directories that are not this plugin's code. */
+	const EXCLUDED_DIRS = [ 'vendor', 'vendor-bin', 'node_modules', 'tests', '.git', 'res', 'dist', 'build' ];
+
+	const BINDING = '/(?:add_action|Hooks::onAction|add_ajax_action)\s*\(\s*(?:\'(?:wp_ajax_|admin_post_|wpmuadminedit)|"(?:wp_ajax_|admin_post_|wpmuadminedit))/';
+
+	/** @test */
+	public function every_request_transport_binding_goes_through_the_adapter() {
+		$root      = dirname( __DIR__, 4 );
+		$offenders = [];
+		$files     = 0;
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveCallbackFilterIterator(
+				new \RecursiveDirectoryIterator( $root, \FilesystemIterator::SKIP_DOTS ),
+				function ( \SplFileInfo $current ) {
+					if ( $current->isDir() ) {
+						return ! in_array( $current->getFilename(), self::EXCLUDED_DIRS, true );
+					}
+
+					return 'php' === $current->getExtension();
+				}
+			)
+		);
+
+		foreach ( $iterator as $file ) {
+			$files++;
+			$relative = ltrim( str_replace( $root, '', (string) $file ), '/' );
+			if ( self::SHIM === $relative ) {
+				continue;
+			}
+			$source = self::withoutComments( (string) file_get_contents( (string) $file ) );
+			if ( preg_match_all( self::BINDING, $source, $matches ) ) {
+				foreach ( $matches[0] as $match ) {
+					$offenders[] = $relative . ': ' . trim( $match );
+				}
+			}
+			if ( false !== strpos( $source, 'register_rest_route(' ) && false === strpos( $source, 'Rest::permission(' ) ) {
+				$offenders[] = $relative . ': register_rest_route() without a Policy permission callback';
+			}
+			if ( false !== strpos( $source, "'xmlrpc_methods'" ) && false === strpos( $source, 'XmlRpc::method(' ) ) {
+				$offenders[] = $relative . ': xmlrpc_methods entries not bound through XmlRpc::method()';
+			}
+		}
+
+		$this->assertGreaterThan( 0, $files, 'the plugin tree must be enumerated' );
+		$this->assertSame(
+			[],
+			$offenders,
+			"These request-transport bindings declare no policy; bind them through " . self::SHIM . " (register()/listen()):\n - " . implode( "\n - ", $offenders )
+		);
+	}
+
+	/** @test */
+	public function the_checker_catches_a_raw_binding() {
+		$this->assertSame( 1, preg_match( self::BINDING, "add_action( 'wp_ajax_x', [ \$this, 'cb' ] );" ) );
+		$this->assertSame( 1, preg_match( self::BINDING, "add_action( 'wp_ajax_nopriv_x', [ \$this, 'cb' ] );" ) );
+		$this->assertSame( 1, preg_match( self::BINDING, "add_action(\n\t'wp_ajax_' . self::ACTION,\n\t[ \$this, 'cb' ] );" ) );
+		$this->assertSame( 1, preg_match( self::BINDING, "add_action( 'admin_post_x', 'cb' );" ) );
+		$this->assertSame( 1, preg_match( self::BINDING, "Hooks::onAction( 'wp_ajax_elementor_ajax' )" ) );
+		$this->assertSame( 0, preg_match( self::BINDING, "\\WPML\\ElasticPress\\Request\\Ajax::register( 'x', [ 'capability' => 'c' ], [ \$this, 'cb' ] );" ) );
+		$this->assertSame( 0, preg_match( self::BINDING, "add_action( 'init', [ \$this, 'cb' ] );" ) );
+	}
+
+	private static function withoutComments( $source ) {
+		$out = '';
+		foreach ( token_get_all( $source ) as $token ) {
+			if ( is_array( $token ) ) {
+				if ( in_array( $token[0], [ T_COMMENT, T_DOC_COMMENT ], true ) ) {
+					continue;
+				}
+				$out .= $token[1];
+			} else {
+				$out .= $token;
+			}
+		}
+
+		return $out;
+	}
+}


### PR DESCRIPTION
## Summary

Two related changes to how this plugin handles requests.

## Changes

**Requester-selected search language**

The plugin resolves its language list before `init`, when WPML's show_hidden() is true for every request, so that list always includes hidden languages. That is correct for indexing. For a search, the requester-selected language is now validated at query time against the viewer-sensitive active-language set that Core resolves after `init`.

**Request-policy adapter for admin-ajax**

- Adds `WPML\ElasticPress\Request\Ajax`, which registers the plugin's admin-ajax handlers with a declarative policy spec. With WPML core's request-policy model available the spec becomes a core Policy; on an older core the handler is registered as before.
- Declares the `ep_index` and `ep_cancel_index` riders as listeners on ElasticPress's own dashboard-sync actions. `isDashboardSync()` now checks ElasticPress's sync capability directly, matching `DashboardRest`.
- Adds a coverage test that fails on any raw `wp_ajax_` or `admin_post_` binding outside the adapter.
- Adds a PHPStan stub for the core request-policy classes.

## Testing

- `vendor/bin/phpunit` and `vendor/bin/phpstan` pass locally.
- The "PHP TEST" CI workflow passed on the branch.